### PR TITLE
Added in Nix Flake Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Prevents accidental commits of the binary when testing Nix Flake builds
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Use HSLS Shaders to render a wallpaper/desktop background. Supports Wayland compositors.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        # Grab Packages
+        pkgs = nixpkgs.legacyPackages.${system};
+        package_name = "shaderbg";
+        # Required at build time
+        nativeBuildInputs = [
+          pkgs.meson
+          pkgs.ninja
+          pkgs.cmake
+          pkgs.pkg-config
+
+          pkgs.libGLU
+          pkgs.wayland
+          pkgs.wayland-scanner
+        ];
+      in {
+        packages = rec {
+          shaderbg = pkgs.stdenv.mkDerivation {
+            src = ./.;
+            name = "${package_name}";
+            version = "0.0.1";
+            inherit nativeBuildInputs;
+            configurePhase = ''
+              meson setup builddir && cd builddir
+            '';
+            buildPhase = ''
+              meson compile
+            '';
+            testPhase = ''
+              meson test
+            '';
+            installPhase = ''
+              mkdir -p $out/bin
+              cp ${package_name} $out/bin/
+            '';
+          };
+          default = shaderbg;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Created `flake.nix` (which generates `flake.lock`) which allows Nix + Flake users to build and include this package as part of their system.
Added `.gitignore` to help prevent accidental pushes of the `result/` directory created when built with Nix + Flakes.

Hello, love the project and its Wayland support. I'm cobbling together my own DE from various projects for personal use, and use Nix + Flakes to help me keep track of all the complexity. Figured I would upstream the addition of a Flake to the main project to remove one layer of indirection (and make it easier for other Nix + Flake users to incorporate `shaderbg` into their DE as well).

Caveat: Only tested on my AARCH64-LINUX laptop; mostly confident the packages required to build it are available on all common systems.

